### PR TITLE
Add no-claude-code-footer skill

### DIFF
--- a/claude/skills/no-claude-code-footer/SKILL.md
+++ b/claude/skills/no-claude-code-footer/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: no-claude-code-footer
+description: Ensures pull request descriptions never include the Claude Code generated footer. Apply this whenever creating pull requests.
+disable-model-invocation: false
+user-invocable: false
+---
+
+# Pull Request Rules
+
+Never add the "Generated with Claude Code" footer or any similar attribution line to pull request descriptions.


### PR DESCRIPTION
## Summary
- Add skill that prevents the "Generated with Claude Code" footer from being added to PR descriptions
- Follows same pattern as existing `no-co-authored-by` skill

## Test plan
- [ ] Verify skill is picked up after symlinking with `install.py --claude`
- [ ] Create a test PR and confirm no footer is added