### PR TITLE
Replace oh-my-zsh with Fish + Starship

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,3 +42,13 @@ dotfiles/
 - `~/.extra.fish` — sourced by config.fish for private/machine-specific config
 - `~/gitconfig/config` — included by .gitconfig for local overrides
 - `~/.tmux.conf.user` — optionally sourced by .tmux.conf
+
+## Testing
+
+Run tests with [bats-core](https://github.com/bats-core/bats-core):
+
+```bash
+bats test_install.bats
+```
+
+Tests cover symlink creation, idempotency, backup behavior, and dry-run mode for all `install.sh` modules.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ The main entry point is `install.sh` (Bash), which supports modular flags:
 ./install.sh --osx            # Run macOS system tweaks (osx/osx.sh)
 ./install.sh --fish           # Set up Fish shell with Starship prompt
 ./install.sh --claude         # Link Claude Code skills to ~/.claude/skills/
+./install.sh --dry-run        # Preview what would be done without making changes
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Options:
   --osx         Run macOS system tweaks (osx/osx.sh)
   --fish        Set up Fish shell with Starship prompt
   --claude      Link Claude Code skills to ~/.claude/skills/
+  --dry-run     Preview what would be done without making changes
   --help        Show this help message
 ```
 
@@ -55,6 +56,6 @@ Set up [Fish shell](https://fishshell.com/) with [Starship](https://starship.rs/
 
 ## Extras
 
-Another nice idea from [@mathiasbynens](https://github.com/mathiasbynens/dotfiles)):
+Another nice idea from [@mathiasbynens](https://github.com/mathiasbynens/dotfiles):
 Put things that do not belong in a public repository in a _~/.extra.fish_ and let
 _fish/config.fish_ source it for you.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ If you are looking for something that tries to work for everybody, you should pr
 Running _./install.sh_ could:
 
 * Install xcode, Homebrew and programs listed in _brew/Brewfile_.
+* Set up Fish shell with Starship prompt.
 * Link Ghostty terminal config.
 * Link Claude Code skills.
 * Run macOS tweaks.
@@ -21,7 +22,7 @@ Options:
   --ghostty     Link Ghostty config to ~/.config/ghostty/
   --brew        Install Xcode, Homebrew, and packages from Brewfile
   --osx         Run macOS system tweaks (osx/osx.sh)
-  --oh-my-zsh   Install Oh-my-zsh
+  --fish        Set up Fish shell with Starship prompt
   --claude      Link Claude Code skills to ~/.claude/skills/
   --help        Show this help message
 ```
@@ -42,9 +43,9 @@ Install xcode, Brew, add taps and Casks. See _brew/Brewfile_ for the list of pro
 
 Link Claude Code skills from _claude/skills/_ to _~/.claude/skills/_.
 
-## Oh-my-zsh
+## Fish + Starship
 
-Install oh-my-zsh.
+Set up [Fish shell](https://fishshell.com/) with [Starship](https://starship.rs/) prompt. Uses JetBrains Mono Nerd Font for icons. Config files are in _fish/config.fish_ and _starship/starship.toml_.
 
 ## Thanks!
 
@@ -55,5 +56,5 @@ Install oh-my-zsh.
 ## Extras
 
 Another nice idea from [@mathiasbynens](https://github.com/mathiasbynens/dotfiles)):
-Put things that do not belong in a public repository in a _~/.extra_ and let
-_zsh/.zshrc_ source it for you.
+Put things that do not belong in a public repository in a _~/.extra.fish_ and let
+_fish/config.fish_ source it for you.


### PR DESCRIPTION
## Summary
- Replace oh-my-zsh/zsh with Fish shell and Starship prompt
- Add JetBrains Mono Nerd Font with icons for git branch, directory, and cmd duration
- Configure Ghostty to use the Nerd Font
- Add CI workflow, dry-run mode, timestamped backups, and expanded bats tests
- Update README and CLAUDE.md to reflect all changes

## Test plan
- [x] `bats test_install.bats` — all 13 tests pass
- [x] Run `brew bundle --file=brew/Brewfile` to install the font
- [x] Restart Ghostty — verify Fish launches as default shell
- [x] Verify Starship prompt shows Nerd Font icons for git branch, directory, etc.