### PR TITLE
Replace autojump with zoxide

### DIFF
--- a/brew/Brewfile
+++ b/brew/Brewfile
@@ -1,4 +1,4 @@
-brew 'autojump'
+brew 'zoxide'
 brew 'bats-core'
 brew 'coreutils'
 brew 'fish'

--- a/fish/config.fish
+++ b/fish/config.fish
@@ -4,9 +4,9 @@ set -gx COPYFILE_DISABLE 1
 # Brew
 fish_add_path /opt/homebrew/bin /opt/homebrew/sbin
 
-# Autojump
-if test -f (brew --prefix)/share/autojump/autojump.fish
-    source (brew --prefix)/share/autojump/autojump.fish
+# Zoxide
+if type -q zoxide
+    zoxide init fish | source
 end
 
 # Show us a fortune


### PR DESCRIPTION
## Summary
- Swap autojump for zoxide in Brewfile and Fish config
- Autojump is unmaintained; zoxide is a faster, actively developed drop-in replacement

## Test plan
- [ ] Run `brew install zoxide && brew uninstall autojump`
- [ ] Open a new Fish shell and verify `z` command works
- [ ] Run `./install.sh --dry-run --fish` to confirm setup path