### PR TITLE
Remove stale Chrome defaults and zsh CI exclusion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   lint:
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run ShellCheck
-        run: find . -name '*.sh' -not -path './zsh/*' -print0 | xargs -0 shellcheck
+        run: find . -name '*.sh' -print0 | xargs -0 shellcheck
 
   test:
     runs-on: macos-latest

--- a/osx/osx.sh
+++ b/osx/osx.sh
@@ -399,26 +399,6 @@ defaults write com.apple.messageshelper.MessageController SOInputLineSettings -d
 defaults write com.apple.messageshelper.MessageController SOInputLineSettings -dict-add "continuousSpellCheckingEnabled" -bool false
 
 ###############################################################################
-# Google Chrome & Google Chrome Canary                                        #
-###############################################################################
-
-# Allow installing user scripts via GitHub Gist or Userscripts.org
-defaults write com.google.Chrome ExtensionInstallSources -array "https://gist.githubusercontent.com/" "http://userscripts.org/*"
-defaults write com.google.Chrome.canary ExtensionInstallSources -array "https://gist.githubusercontent.com/" "http://userscripts.org/*"
-
-# Disable the all too sensitive backswipe on trackpads
-defaults write com.google.Chrome AppleEnableSwipeNavigateWithScrolls -bool false
-defaults write com.google.Chrome.canary AppleEnableSwipeNavigateWithScrolls -bool false
-
-# Disable the all too sensitive backswipe on Magic Mouse
-defaults write com.google.Chrome AppleEnableMouseSwipeNavigateWithScrolls -bool false
-defaults write com.google.Chrome.canary AppleEnableMouseSwipeNavigateWithScrolls -bool false
-
-# Use the system-native print preview dialog
-defaults write com.google.Chrome DisablePrintPreview -bool true
-defaults write com.google.Chrome.canary DisablePrintPreview -bool true
-
-###############################################################################
 # Kill affected applications                                                  #
 ###############################################################################
 


### PR DESCRIPTION
## Summary
- Remove Google Chrome/Canary settings from `osx/osx.sh` (Chrome not in Brewfile)
- Drop dead `./zsh/*` exclusion from CI shellcheck (zsh directory no longer exists)
- Fix CI triggers from `master` to `main`

## Test plan
- [ ] CI passes on this PR (shellcheck + bats)